### PR TITLE
Add cluster activation before tests if then in inactive state, print …

### DIFF
--- a/src/main/java/org/alex/IgniteCacheTest.java
+++ b/src/main/java/org/alex/IgniteCacheTest.java
@@ -7,6 +7,7 @@ package org.alex;
 
 import org.apache.ignite.Ignition;
 import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.cluster.ClusterState;
 import org.apache.ignite.configuration.ClientConfiguration;
 
 import static org.alex.KeyValueCacheTest.startKVCacheTest;
@@ -20,6 +21,20 @@ public class IgniteCacheTest {
         cfg.setPartitionAwarenessEnabled(true);
 
         try (IgniteClient client = Ignition.startClient(cfg)) {
+            System.out.println("Cluster is in " + client.cluster().state().name() + " state.\n");
+            if (client.cluster().state() == ClusterState.INACTIVE || client.cluster().state() == ClusterState.ACTIVE_READ_ONLY) {
+                client.cluster().state(ClusterState.ACTIVE);
+                // Maybe we need some delay for cluster activation
+                System.out.println("Now cluster is in " + client.cluster().state().name() + " state.\n");
+            }
+
+
+            if (client.cacheNames().size() > 0) {
+                System.out.println("Caches detected:");
+                client.cacheNames().forEach((v) -> System.out.println(v));
+                System.out.println();
+            }
+
             // Tests with Key Value cache
             startKVCacheTest(client);
         }


### PR DESCRIPTION
…detected before test caches